### PR TITLE
Add GitHub discussions link to the header

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -22,6 +22,8 @@ github:
   repo:           https://github.com/KowalskiPiotr98/KowalskiPiotr98.github.io
 
 nav:
+  - title: Discuss
+    url: https://github.com/KowalskiPiotr98/KowalskiPiotr98.github.io/discussions
   - title: Software
     url: /software
   - title: Archive


### PR DESCRIPTION
This is my primitive way of adding "comments" to the blog posts.